### PR TITLE
Refactor the render code w/ simpler component structure

### DIFF
--- a/js/render.js
+++ b/js/render.js
@@ -16,13 +16,29 @@ function unHidePlan() {
     removeClass(document.getElementById('prettyplan'), 'hidden');
 }
 
+var components = {
+    id: (id) => `
+        <span class="id">
+            ${id.prefixes.map(prefix => 
+                `<span class="id-segment prefix">${prefix}</span>`
+            ).join('')}
+            <span class="id-segment type">${id.type}</span>
+            <span class="id-segment name">${id.name}</span>
+        </span>
+    `,
+    warning: (warning) => `
+        <li>
+            <span class="badge">warning</span>
+            ${components.id(warning.id)}
+            <span>${warning.detail}</span>
+        </li>
+    `
+};
+
 function render(plan) {
     if (plan.warnings) {
         var warningList = document.getElementById('warnings');
-        for (var i = 0; i < plan.warnings.length; i++) {
-            var warning = createWarningElement(plan.warnings[i], warningList);
-            warningList.appendChild(warning);
-        }
+        warningList.innerHTML = `${plan.warnings.map(components.warning).join('')}`;
     }
 
     if (plan.actions) {
@@ -32,22 +48,6 @@ function render(plan) {
             actionList.appendChild(action);
         }
     }
-}
-
-function createWarningElement(warning) {
-    var badge = createBadgeElement('warning');
-
-    var id = createIdElement(warning.id);
-
-    var detail = document.createElement('span');
-    detail.innerText = warning.detail;
-
-    var warningElement = document.createElement('li');
-    warningElement.appendChild(badge);
-    warningElement.appendChild(id);
-    warningElement.appendChild(detail);
-
-    return warningElement;
 }
 
 function createActionElement(action) {

--- a/js/render.js
+++ b/js/render.js
@@ -28,28 +28,6 @@ function render(plan) {
     }
 }
 
-function prettify(value) {
-    if (value.indexOf('\\n') >= 0 || value.indexOf('\\"') >= 0) {
-        var sanitisedValue = value.replace(new RegExp('\\\\n', 'g'), '\n')
-                                    .replace(new RegExp('\\\\"', 'g'), '"');
-        
-        sanitisedValue = prettifyJson(sanitisedValue);
-        return `<pre>${sanitisedValue}</pre>`;
-    }
-    else {
-        return value;
-    }
-}
-
-function prettifyJson(json) {
-    try {
-        return JSON.stringify(JSON.parse(json), null, 2);
-    }
-    catch (e) {
-        return json;
-    }
-}
-
 const components = {
     badge: (label) => `
         <span class="badge">${label}</span>
@@ -102,3 +80,25 @@ const components = {
         </li>
     `
 };
+
+function prettify(value) {
+    if (value.indexOf('\\n') >= 0 || value.indexOf('\\"') >= 0) {
+        var sanitisedValue = value.replace(new RegExp('\\\\n', 'g'), '\n')
+                                    .replace(new RegExp('\\\\"', 'g'), '"');
+        
+        sanitisedValue = prettifyJson(sanitisedValue);
+        return `<pre>${sanitisedValue}</pre>`;
+    }
+    else {
+        return value;
+    }
+}
+
+function prettifyJson(maybeJson) {
+    try {
+        return JSON.stringify(JSON.parse(maybeJson), null, 2);
+    }
+    catch (e) {
+        return maybeJson;
+    }
+}


### PR DESCRIPTION
The render code was quite difficult to read and maintain, so I saw fit to replace it with something more akin to a component-based system using HTML template strings.

Although the resulting code is a bit stringly typed, it's considerably more readable and easier to work with. It retains the simplicity of our vanilla JS approach while reading a little bit more like you'd read, say, React code.