### PR TITLE
Fix display of <computed> values

### DIFF
--- a/js/releases.js
+++ b/js/releases.js
@@ -13,6 +13,13 @@ function updateLastUsedVersion() {
 //New releases should always go at the top of this list.
 var releases = [
     {
+        version: 'v1.2',
+        notes: [
+            '<em>&lt;computed&gt;</em> values now display properly instead of being interpreted as HTML (<a target="_blank" href="https://github.com/chrislewisdev/prettyplan/issues/2">#2</a>)',
+            'Italics for <em>&lt;computed&gt;</em> or <em>${variable}</em> values to help set them apart from regular values'
+        ]
+    },
+    {
         version: 'v1.1',
         notes: [
             'Added handy release notes!',

--- a/js/render.js
+++ b/js/render.js
@@ -124,12 +124,19 @@ const components = {
 };
 
 function prettify(value) {
-    if (value.indexOf('\\n') >= 0 || value.indexOf('\\"') >= 0) {
+    if (value === '<computed>')
+    {
+        return `<em>&lt;computed&gt;</em>`;
+    }
+    else if (value.startsWith('${') && value.endsWith('}'))
+    {
+        return `<em>${value}</em>`;
+    }
+    else if (value.indexOf('\\n') >= 0 || value.indexOf('\\"') >= 0) {
         var sanitisedValue = value.replace(new RegExp('\\\\n', 'g'), '\n')
-                                    .replace(new RegExp('\\\\"', 'g'), '"');
+                                  .replace(new RegExp('\\\\"', 'g'), '"');
         
-        sanitisedValue = prettifyJson(sanitisedValue);
-        return `<pre>${sanitisedValue}</pre>`;
+        return `<pre>${prettifyJson(sanitisedValue)}</pre>`;
     }
     else {
         return value;


### PR DESCRIPTION
Fixes #2 

While I was fixing this, I added some italics for <computed> and ${variable} values in plan output, in order to help differentiate them from regular values.